### PR TITLE
Sklearn update

### DIFF
--- a/polyssifier/poly_utils.py
+++ b/polyssifier/poly_utils.py
@@ -125,14 +125,14 @@ def build_classifiers(exclude, scale, feature_selection, nCols):
     if 'Decision Tree' not in exclude:
         classifiers['Decision Tree'] = {
             'clf': DecisionTreeClassifier(max_depth=None,
-                                          max_features='auto'),
+                                          max_features='sqrt'),
             'parameters': {}}
 
     if 'Random Forest' not in exclude:
         classifiers['Random Forest'] = {
             'clf': RandomForestClassifier(max_depth=None,
                                           n_estimators=10,
-                                          max_features='auto'),
+                                          max_features='sqrt'),
             'parameters': {'n_estimators': list(range(5, 20))}}
 
     if 'Logistic Regression' not in exclude:

--- a/polyssifier/polyssifier.py
+++ b/polyssifier/polyssifier.py
@@ -55,8 +55,7 @@ def poly(data, label, n_folds=10, scale=True, exclude=[],
     _le.fit(label)
     label = _le.transform(label)
     n_class = len(np.unique(label))
-    #logger.info(f'Detected {n_class} classes in label')
-    logger.info('Detected ' + str(n_class) + ' classes in label')
+    logger.info(f'Detected {n_class} classes in label')
 
     if save and not os.path.exists('poly_{}/models'.format(project_name)):
         os.makedirs('poly_{}/models'.format(project_name))

--- a/polyssifier/polyssifier.py
+++ b/polyssifier/polyssifier.py
@@ -85,7 +85,7 @@ def poly(data, label, n_folds=10, scale=True, exclude=[],
 
     # Parallel processing of tasks
     
-    if __name__ == '__polyssifier__':
+    if __name__ == '__polyssifier.py__':
 
         manager = Manager()
         args = manager.list()

--- a/polyssifier/polyssifier.py
+++ b/polyssifier/polyssifier.py
@@ -84,14 +84,15 @@ def poly(data, label, n_folds=10, scale=True, exclude=[],
     kf = list(skf.split(np.zeros(data.shape[0]), label))
 
     # Parallel processing of tasks
-    manager = Manager()
-    args = manager.list()
-    args.append({})  # Store inputs
-    shared = args[0]
-    shared['kf'] = kf
-    shared['X'] = data
-    shared['y'] = label
-    args[0] = shared
+    if __name__ == '__main__':
+        manager = Manager()
+        args = manager.list()
+        args.append({})  # Store inputs
+        shared = args[0]
+        shared['kf'] = kf
+        shared['X'] = data
+        shared['y'] = label
+        args[0] = shared
 
     args2 = []
     for clf_name, val in classifiers.items():
@@ -99,13 +100,12 @@ def poly(data, label, n_folds=10, scale=True, exclude=[],
             args2.append((args, clf_name, val, n_fold, project_name,
                           save, scoring))
 
-    if __name__ == '__main__':
-        if concurrency == 1:
-            result = list(starmap(fit_clf, args2))
-        else:
-            pool = Pool(processes=concurrency)
-            result = pool.starmap(fit_clf, args2)
-            pool.close()
+    if concurrency == 1:
+        result = list(starmap(fit_clf, args2))
+    else:
+        pool = Pool(processes=concurrency)
+        result = pool.starmap(fit_clf, args2)
+        pool.close()
 
     fitted_clfs = {key: [] for key in classifiers}
 

--- a/polyssifier/polyssifier.py
+++ b/polyssifier/polyssifier.py
@@ -55,7 +55,8 @@ def poly(data, label, n_folds=10, scale=True, exclude=[],
     _le.fit(label)
     label = _le.transform(label)
     n_class = len(np.unique(label))
-    logger.info(f'Detected {n_class} classes in label')
+    #logger.info(f'Detected {n_class} classes in label')
+    logger.info('Detected ' + str(n_class) + ' classes in label')
 
     if save and not os.path.exists('poly_{}/models'.format(project_name)):
         os.makedirs('poly_{}/models'.format(project_name))

--- a/polyssifier/polyssifier.py
+++ b/polyssifier/polyssifier.py
@@ -55,7 +55,7 @@ def poly(data, label, n_folds=10, scale=True, exclude=[],
     _le.fit(label)
     label = _le.transform(label)
     n_class = len(np.unique(label))
-    logger.info(f'Detected {n_class} classes in label')
+    logger.info('Detected ' + str(n_class) + ' classes in label')
 
     if save and not os.path.exists('poly_{}/models'.format(project_name)):
         os.makedirs('poly_{}/models'.format(project_name))

--- a/polyssifier/polyssifier.py
+++ b/polyssifier/polyssifier.py
@@ -99,10 +99,10 @@ def poly(data, label, n_folds=10, scale=True, exclude=[],
             args2.append((args, clf_name, val, n_fold, project_name,
                           save, scoring))
 
-    if concurrency == 1:
-        result = list(starmap(fit_clf, args2))
-    else:
-        if __name__ == '__main__':
+    if __name__ == '__main__':
+        if concurrency == 1:
+            result = list(starmap(fit_clf, args2))
+        else:
             pool = Pool(processes=concurrency)
             result = pool.starmap(fit_clf, args2)
             pool.close()

--- a/polyssifier/polyssifier.py
+++ b/polyssifier/polyssifier.py
@@ -94,18 +94,18 @@ def poly(data, label, n_folds=10, scale=True, exclude=[],
         shared['y'] = label
         args[0] = shared
 
-    args2 = []
-    for clf_name, val in classifiers.items():
-        for n_fold in range(n_folds):
-            args2.append((args, clf_name, val, n_fold, project_name,
-                          save, scoring))
+        args2 = []
+        for clf_name, val in classifiers.items():
+            for n_fold in range(n_folds):
+                args2.append((args, clf_name, val, n_fold, project_name,
+                              save, scoring))
 
-    if concurrency == 1:
-        result = list(starmap(fit_clf, args2))
-    else:
-        pool = Pool(processes=concurrency)
-        result = pool.starmap(fit_clf, args2)
-        pool.close()
+        if concurrency == 1:
+            result = list(starmap(fit_clf, args2))
+        else:
+            pool = Pool(processes=concurrency)
+            result = pool.starmap(fit_clf, args2)
+            pool.close()
 
     fitted_clfs = {key: [] for key in classifiers}
 

--- a/polyssifier/polyssifier.py
+++ b/polyssifier/polyssifier.py
@@ -85,7 +85,7 @@ def poly(data, label, n_folds=10, scale=True, exclude=[],
 
     # Parallel processing of tasks
     
-    if __name__ == '__polyssifier.py__':
+    if __name__ == 'polyssifier.py':
 
         manager = Manager()
         args = manager.list()

--- a/polyssifier/polyssifier.py
+++ b/polyssifier/polyssifier.py
@@ -109,62 +109,62 @@ def poly(data, label, n_folds=10, scale=True, exclude=[],
             result = pool.starmap(fit_clf, args2)
             pool.close()
 
-        fitted_clfs = {key: [] for key in classifiers}
+    fitted_clfs = {key: [] for key in classifiers}
 
-        # Gather results
-        for clf_name in classifiers:
-            coefficients[clf_name] = []
-            temp = np.zeros((n_class, n_class))
-            temp_pred = np.zeros((data.shape[0], ))
-            temp_prob = np.zeros((data.shape[0], ))
-            clfs = fitted_clfs[clf_name]
-            for n in range(n_folds):
-                train_score, test_score, prediction, prob, confusion,\
-                    coefs, fitted_clf = result.pop(0)
-                clfs.append(fitted_clf)
-                scores.loc[n, (clf_name, 'train')] = train_score
-                scores.loc[n, (clf_name, 'test')] = test_score
-                temp += confusion
-                temp_prob[kf[n][1]] = prob
-                temp_pred[kf[n][1]] = _le.inverse_transform(prediction)
-                coefficients[clf_name].append(coefs)
-
-            confusions[clf_name] = temp
-            predictions[clf_name] = temp_pred
-            test_prob[clf_name] = temp_prob
-
-        # Voting
-        fitted_clfs = pd.DataFrame(fitted_clfs)
-        scores['Voting', 'train'] = np.zeros((n_folds, ))
-        scores['Voting', 'test'] = np.zeros((n_folds, ))
+    # Gather results
+    for clf_name in classifiers:
+        coefficients[clf_name] = []
         temp = np.zeros((n_class, n_class))
         temp_pred = np.zeros((data.shape[0], ))
-        for n, (train, test) in enumerate(kf):
-            clf = MyVoter(fitted_clfs.loc[n].values)
-            X, y = data[train, :], label[train]
-            scores.loc[n, ('Voting', 'train')] = _scorer(clf, X, y)
-            X, y = data[test, :], label[test]
-            scores.loc[n, ('Voting', 'test')] = _scorer(clf, X, y)
-            temp_pred[test] = clf.predict(X)
-            temp += confusion_matrix(y, temp_pred[test])
+        temp_prob = np.zeros((data.shape[0], ))
+        clfs = fitted_clfs[clf_name]
+        for n in range(n_folds):
+            train_score, test_score, prediction, prob, confusion,\
+                coefs, fitted_clf = result.pop(0)
+            clfs.append(fitted_clf)
+            scores.loc[n, (clf_name, 'train')] = train_score
+            scores.loc[n, (clf_name, 'test')] = test_score
+            temp += confusion
+            temp_prob[kf[n][1]] = prob
+            temp_pred[kf[n][1]] = _le.inverse_transform(prediction)
+            coefficients[clf_name].append(coefs)
 
-        confusions['Voting'] = temp
-        predictions['Voting'] = temp_pred
-        test_prob['Voting'] = temp_pred
-        ######
+        confusions[clf_name] = temp
+        predictions[clf_name] = temp_pred
+        test_prob[clf_name] = temp_prob
 
-        # saving confusion matrices
-        if save:
-            with open('poly_' + project_name + '/confusions.pkl', 'wb') as f:
-                p.dump(confusions, f, protocol=2)
+    # Voting
+    fitted_clfs = pd.DataFrame(fitted_clfs)
+    scores['Voting', 'train'] = np.zeros((n_folds, ))
+    scores['Voting', 'test'] = np.zeros((n_folds, ))
+    temp = np.zeros((n_class, n_class))
+    temp_pred = np.zeros((data.shape[0], ))
+    for n, (train, test) in enumerate(kf):
+        clf = MyVoter(fitted_clfs.loc[n].values)
+        X, y = data[train, :], label[train]
+        scores.loc[n, ('Voting', 'train')] = _scorer(clf, X, y)
+        X, y = data[test, :], label[test]
+        scores.loc[n, ('Voting', 'test')] = _scorer(clf, X, y)
+        temp_pred[test] = clf.predict(X)
+        temp += confusion_matrix(y, temp_pred[test])
 
-        if verbose:
-            print(scores.astype('float').describe().transpose()
-                  [['mean', 'std', 'min', 'max']])
-        return Report(scores=scores, confusions=confusions,
-                      predictions=predictions, test_prob=test_prob,
-                      coefficients=coefficients,
-                      feature_selection=feature_selection)
+    confusions['Voting'] = temp
+    predictions['Voting'] = temp_pred
+    test_prob['Voting'] = temp_pred
+    ######
+
+    # saving confusion matrices
+    if save:
+        with open('poly_' + project_name + '/confusions.pkl', 'wb') as f:
+            p.dump(confusions, f, protocol=2)
+
+    if verbose:
+        print(scores.astype('float').describe().transpose()
+              [['mean', 'std', 'min', 'max']])
+    return Report(scores=scores, confusions=confusions,
+                  predictions=predictions, test_prob=test_prob,
+                  coefficients=coefficients,
+                  feature_selection=feature_selection)
 
 
 def _scorer(clf, X, y):

--- a/polyssifier/polyssifier.py
+++ b/polyssifier/polyssifier.py
@@ -85,7 +85,6 @@ def poly(data, label, n_folds=10, scale=True, exclude=[],
 
     # Parallel processing of tasks
     
-
     manager = Manager()
     args = manager.list()
     args.append({})  # Store inputs

--- a/polyssifier/polyssifier.py
+++ b/polyssifier/polyssifier.py
@@ -84,81 +84,80 @@ def poly(data, label, n_folds=10, scale=True, exclude=[],
     kf = list(skf.split(np.zeros(data.shape[0]), label))
 
     # Parallel processing of tasks
-    if __name__ == '__main__':
-        manager = Manager()
-        args = manager.list()
-        args.append({})  # Store inputs
-        shared = args[0]
-        shared['kf'] = kf
-        shared['X'] = data
-        shared['y'] = label
-        args[0] = shared
+    manager = Manager()
+    args = manager.list()
+    args.append({})  # Store inputs
+    shared = args[0]
+    shared['kf'] = kf
+    shared['X'] = data
+    shared['y'] = label
+    args[0] = shared
 
-        args2 = []
-        for clf_name, val in classifiers.items():
-            for n_fold in range(n_folds):
-                args2.append((args, clf_name, val, n_fold, project_name,
-                              save, scoring))
+    args2 = []
+    for clf_name, val in classifiers.items():
+        for n_fold in range(n_folds):
+            args2.append((args, clf_name, val, n_fold, project_name,
+                          save, scoring))
 
-        if concurrency == 1:
-            result = list(starmap(fit_clf, args2))
-        else:
-            pool = Pool(processes=concurrency)
-            result = pool.starmap(fit_clf, args2)
-            pool.close()
+    if concurrency == 1:
+        result = list(starmap(fit_clf, args2))
+    else:
+        pool = Pool(processes=concurrency)
+        result = pool.starmap(fit_clf, args2)
+        pool.close()
 
-        fitted_clfs = {key: [] for key in classifiers}
+    fitted_clfs = {key: [] for key in classifiers}
 
-        # Gather results
-        for clf_name in classifiers:
-            coefficients[clf_name] = []
-            temp = np.zeros((n_class, n_class))
-            temp_pred = np.zeros((data.shape[0], ))
-            temp_prob = np.zeros((data.shape[0], ))
-            clfs = fitted_clfs[clf_name]
-            for n in range(n_folds):
-                train_score, test_score, prediction, prob, confusion,\
-                    coefs, fitted_clf = result.pop(0)
-                clfs.append(fitted_clf)
-                scores.loc[n, (clf_name, 'train')] = train_score
-                scores.loc[n, (clf_name, 'test')] = test_score
-                temp += confusion
-                temp_prob[kf[n][1]] = prob
-                temp_pred[kf[n][1]] = _le.inverse_transform(prediction)
-                coefficients[clf_name].append(coefs)
-
-            confusions[clf_name] = temp
-            predictions[clf_name] = temp_pred
-            test_prob[clf_name] = temp_prob
-
-        # Voting
-        fitted_clfs = pd.DataFrame(fitted_clfs)
-        scores['Voting', 'train'] = np.zeros((n_folds, ))
-        scores['Voting', 'test'] = np.zeros((n_folds, ))
+    # Gather results
+    for clf_name in classifiers:
+        coefficients[clf_name] = []
         temp = np.zeros((n_class, n_class))
         temp_pred = np.zeros((data.shape[0], ))
-        for n, (train, test) in enumerate(kf):
-            clf = MyVoter(fitted_clfs.loc[n].values)
-            X, y = data[train, :], label[train]
-            scores.loc[n, ('Voting', 'train')] = _scorer(clf, X, y)
-            X, y = data[test, :], label[test]
-            scores.loc[n, ('Voting', 'test')] = _scorer(clf, X, y)
-            temp_pred[test] = clf.predict(X)
-            temp += confusion_matrix(y, temp_pred[test])
+        temp_prob = np.zeros((data.shape[0], ))
+        clfs = fitted_clfs[clf_name]
+        for n in range(n_folds):
+            train_score, test_score, prediction, prob, confusion,\
+                coefs, fitted_clf = result.pop(0)
+            clfs.append(fitted_clf)
+            scores.loc[n, (clf_name, 'train')] = train_score
+            scores.loc[n, (clf_name, 'test')] = test_score
+            temp += confusion
+            temp_prob[kf[n][1]] = prob
+            temp_pred[kf[n][1]] = _le.inverse_transform(prediction)
+            coefficients[clf_name].append(coefs)
 
-        confusions['Voting'] = temp
-        predictions['Voting'] = temp_pred
-        test_prob['Voting'] = temp_pred
-        ######
+        confusions[clf_name] = temp
+        predictions[clf_name] = temp_pred
+        test_prob[clf_name] = temp_prob
 
-        # saving confusion matrices
-        if save:
-            with open('poly_' + project_name + '/confusions.pkl', 'wb') as f:
-                p.dump(confusions, f, protocol=2)
+    # Voting
+    fitted_clfs = pd.DataFrame(fitted_clfs)
+    scores['Voting', 'train'] = np.zeros((n_folds, ))
+    scores['Voting', 'test'] = np.zeros((n_folds, ))
+    temp = np.zeros((n_class, n_class))
+    temp_pred = np.zeros((data.shape[0], ))
+    for n, (train, test) in enumerate(kf):
+        clf = MyVoter(fitted_clfs.loc[n].values)
+        X, y = data[train, :], label[train]
+        scores.loc[n, ('Voting', 'train')] = _scorer(clf, X, y)
+        X, y = data[test, :], label[test]
+        scores.loc[n, ('Voting', 'test')] = _scorer(clf, X, y)
+        temp_pred[test] = clf.predict(X)
+        temp += confusion_matrix(y, temp_pred[test])
 
-        if verbose:
-            print(scores.astype('float').describe().transpose()
-                  [['mean', 'std', 'min', 'max']])
+    confusions['Voting'] = temp
+    predictions['Voting'] = temp_pred
+    test_prob['Voting'] = temp_pred
+    ######
+
+    # saving confusion matrices
+    if save:
+        with open('poly_' + project_name + '/confusions.pkl', 'wb') as f:
+            p.dump(confusions, f, protocol=2)
+
+    if verbose:
+        print(scores.astype('float').describe().transpose()
+              [['mean', 'std', 'min', 'max']])
     return Report(scores=scores, confusions=confusions,
                   predictions=predictions, test_prob=test_prob,
                   coefficients=coefficients,

--- a/polyssifier/polyssifier.py
+++ b/polyssifier/polyssifier.py
@@ -85,7 +85,7 @@ def poly(data, label, n_folds=10, scale=True, exclude=[],
 
     # Parallel processing of tasks
     
-    if __name__ == 'polyssifier.py':
+    if __name__ == 'polyssifier':
 
         manager = Manager()
         args = manager.list()

--- a/polyssifier/polyssifier.py
+++ b/polyssifier/polyssifier.py
@@ -84,85 +84,85 @@ def poly(data, label, n_folds=10, scale=True, exclude=[],
     kf = list(skf.split(np.zeros(data.shape[0]), label))
 
     # Parallel processing of tasks
-    if __name__ == '__main__':
-        manager = Manager()
-        args = manager.list()
-        args.append({})  # Store inputs
-        shared = args[0]
-        shared['kf'] = kf
-        shared['X'] = data
-        shared['y'] = label
-        args[0] = shared
+    manager = Manager()
+    args = manager.list()
+    args.append({})  # Store inputs
+    shared = args[0]
+    shared['kf'] = kf
+    shared['X'] = data
+    shared['y'] = label
+    args[0] = shared
 
-        args2 = []
-        for clf_name, val in classifiers.items():
-            for n_fold in range(n_folds):
-                args2.append((args, clf_name, val, n_fold, project_name,
-                              save, scoring))
+    args2 = []
+    for clf_name, val in classifiers.items():
+        for n_fold in range(n_folds):
+            args2.append((args, clf_name, val, n_fold, project_name,
+                          save, scoring))
 
-        if concurrency == 1:
-            result = list(starmap(fit_clf, args2))
-        else:
+    if concurrency == 1:
+        result = list(starmap(fit_clf, args2))
+    else:
+        if __name__ == '__main__':
             pool = Pool(processes=concurrency)
             result = pool.starmap(fit_clf, args2)
             pool.close()
 
-        fitted_clfs = {key: [] for key in classifiers}
+    fitted_clfs = {key: [] for key in classifiers}
 
-        # Gather results
-        for clf_name in classifiers:
-            coefficients[clf_name] = []
-            temp = np.zeros((n_class, n_class))
-            temp_pred = np.zeros((data.shape[0], ))
-            temp_prob = np.zeros((data.shape[0], ))
-            clfs = fitted_clfs[clf_name]
-            for n in range(n_folds):
-                train_score, test_score, prediction, prob, confusion,\
-                    coefs, fitted_clf = result.pop(0)
-                clfs.append(fitted_clf)
-                scores.loc[n, (clf_name, 'train')] = train_score
-                scores.loc[n, (clf_name, 'test')] = test_score
-                temp += confusion
-                temp_prob[kf[n][1]] = prob
-                temp_pred[kf[n][1]] = _le.inverse_transform(prediction)
-                coefficients[clf_name].append(coefs)
-
-            confusions[clf_name] = temp
-            predictions[clf_name] = temp_pred
-            test_prob[clf_name] = temp_prob
-
-        # Voting
-        fitted_clfs = pd.DataFrame(fitted_clfs)
-        scores['Voting', 'train'] = np.zeros((n_folds, ))
-        scores['Voting', 'test'] = np.zeros((n_folds, ))
+    # Gather results
+    for clf_name in classifiers:
+        coefficients[clf_name] = []
         temp = np.zeros((n_class, n_class))
         temp_pred = np.zeros((data.shape[0], ))
-        for n, (train, test) in enumerate(kf):
-            clf = MyVoter(fitted_clfs.loc[n].values)
-            X, y = data[train, :], label[train]
-            scores.loc[n, ('Voting', 'train')] = _scorer(clf, X, y)
-            X, y = data[test, :], label[test]
-            scores.loc[n, ('Voting', 'test')] = _scorer(clf, X, y)
-            temp_pred[test] = clf.predict(X)
-            temp += confusion_matrix(y, temp_pred[test])
+        temp_prob = np.zeros((data.shape[0], ))
+        clfs = fitted_clfs[clf_name]
+        for n in range(n_folds):
+            train_score, test_score, prediction, prob, confusion,\
+                coefs, fitted_clf = result.pop(0)
+            clfs.append(fitted_clf)
+            scores.loc[n, (clf_name, 'train')] = train_score
+            scores.loc[n, (clf_name, 'test')] = test_score
+            temp += confusion
+            temp_prob[kf[n][1]] = prob
+            temp_pred[kf[n][1]] = _le.inverse_transform(prediction)
+            coefficients[clf_name].append(coefs)
 
-        confusions['Voting'] = temp
-        predictions['Voting'] = temp_pred
-        test_prob['Voting'] = temp_pred
-        ######
+        confusions[clf_name] = temp
+        predictions[clf_name] = temp_pred
+        test_prob[clf_name] = temp_prob
 
-        # saving confusion matrices
-        if save:
-            with open('poly_' + project_name + '/confusions.pkl', 'wb') as f:
-                p.dump(confusions, f, protocol=2)
+    # Voting
+    fitted_clfs = pd.DataFrame(fitted_clfs)
+    scores['Voting', 'train'] = np.zeros((n_folds, ))
+    scores['Voting', 'test'] = np.zeros((n_folds, ))
+    temp = np.zeros((n_class, n_class))
+    temp_pred = np.zeros((data.shape[0], ))
+    for n, (train, test) in enumerate(kf):
+        clf = MyVoter(fitted_clfs.loc[n].values)
+        X, y = data[train, :], label[train]
+        scores.loc[n, ('Voting', 'train')] = _scorer(clf, X, y)
+        X, y = data[test, :], label[test]
+        scores.loc[n, ('Voting', 'test')] = _scorer(clf, X, y)
+        temp_pred[test] = clf.predict(X)
+        temp += confusion_matrix(y, temp_pred[test])
 
-        if verbose:
-            print(scores.astype('float').describe().transpose()
-                  [['mean', 'std', 'min', 'max']])
-        return Report(scores=scores, confusions=confusions,
-                      predictions=predictions, test_prob=test_prob,
-                      coefficients=coefficients,
-                      feature_selection=feature_selection)
+    confusions['Voting'] = temp
+    predictions['Voting'] = temp_pred
+    test_prob['Voting'] = temp_pred
+    ######
+
+    # saving confusion matrices
+    if save:
+        with open('poly_' + project_name + '/confusions.pkl', 'wb') as f:
+            p.dump(confusions, f, protocol=2)
+
+    if verbose:
+        print(scores.astype('float').describe().transpose()
+              [['mean', 'std', 'min', 'max']])
+    return Report(scores=scores, confusions=confusions,
+                  predictions=predictions, test_prob=test_prob,
+                  coefficients=coefficients,
+                  feature_selection=feature_selection)
 
 
 def _scorer(clf, X, y):

--- a/polyssifier/polyssifier.py
+++ b/polyssifier/polyssifier.py
@@ -84,6 +84,7 @@ def poly(data, label, n_folds=10, scale=True, exclude=[],
     kf = list(skf.split(np.zeros(data.shape[0]), label))
 
     # Parallel processing of tasks
+    print(__name__)
     if __name__ == '__main__':
         manager = Manager()
         args = manager.list()

--- a/polyssifier/polyssifier.py
+++ b/polyssifier/polyssifier.py
@@ -84,27 +84,30 @@ def poly(data, label, n_folds=10, scale=True, exclude=[],
     kf = list(skf.split(np.zeros(data.shape[0]), label))
 
     # Parallel processing of tasks
-    manager = Manager()
-    args = manager.list()
-    args.append({})  # Store inputs
-    shared = args[0]
-    shared['kf'] = kf
-    shared['X'] = data
-    shared['y'] = label
-    args[0] = shared
+    
+    if __name__ == '__polyssifier__':
 
-    args2 = []
-    for clf_name, val in classifiers.items():
-        for n_fold in range(n_folds):
-            args2.append((args, clf_name, val, n_fold, project_name,
-                          save, scoring))
+        manager = Manager()
+        args = manager.list()
+        args.append({})  # Store inputs
+        shared = args[0]
+        shared['kf'] = kf
+        shared['X'] = data
+        shared['y'] = label
+        args[0] = shared
 
-    if concurrency == 1:
-        result = list(starmap(fit_clf, args2))
-    else:
-        pool = Pool(processes=concurrency)
-        result = pool.starmap(fit_clf, args2)
-        pool.close()
+        args2 = []
+        for clf_name, val in classifiers.items():
+            for n_fold in range(n_folds):
+                args2.append((args, clf_name, val, n_fold, project_name,
+                              save, scoring))
+
+        if concurrency == 1:
+            result = list(starmap(fit_clf, args2))
+        else:
+            pool = Pool(processes=concurrency)
+            result = pool.starmap(fit_clf, args2)
+            pool.close()
 
     fitted_clfs = {key: [] for key in classifiers}
 

--- a/polyssifier/polyssifier.py
+++ b/polyssifier/polyssifier.py
@@ -84,7 +84,6 @@ def poly(data, label, n_folds=10, scale=True, exclude=[],
     kf = list(skf.split(np.zeros(data.shape[0]), label))
 
     # Parallel processing of tasks
-    print(__name__)
     if __name__ == '__main__':
         manager = Manager()
         args = manager.list()
@@ -160,10 +159,10 @@ def poly(data, label, n_folds=10, scale=True, exclude=[],
         if verbose:
             print(scores.astype('float').describe().transpose()
                   [['mean', 'std', 'min', 'max']])
-        return Report(scores=scores, confusions=confusions,
-                      predictions=predictions, test_prob=test_prob,
-                      coefficients=coefficients,
-                      feature_selection=feature_selection)
+    return Report(scores=scores, confusions=confusions,
+                  predictions=predictions, test_prob=test_prob,
+                  coefficients=coefficients,
+                  feature_selection=feature_selection)
 
 
 def _scorer(clf, X, y):

--- a/polyssifier/polyssifier.py
+++ b/polyssifier/polyssifier.py
@@ -109,62 +109,62 @@ def poly(data, label, n_folds=10, scale=True, exclude=[],
             result = pool.starmap(fit_clf, args2)
             pool.close()
 
-    fitted_clfs = {key: [] for key in classifiers}
+        fitted_clfs = {key: [] for key in classifiers}
 
-    # Gather results
-    for clf_name in classifiers:
-        coefficients[clf_name] = []
+        # Gather results
+        for clf_name in classifiers:
+            coefficients[clf_name] = []
+            temp = np.zeros((n_class, n_class))
+            temp_pred = np.zeros((data.shape[0], ))
+            temp_prob = np.zeros((data.shape[0], ))
+            clfs = fitted_clfs[clf_name]
+            for n in range(n_folds):
+                train_score, test_score, prediction, prob, confusion,\
+                    coefs, fitted_clf = result.pop(0)
+                clfs.append(fitted_clf)
+                scores.loc[n, (clf_name, 'train')] = train_score
+                scores.loc[n, (clf_name, 'test')] = test_score
+                temp += confusion
+                temp_prob[kf[n][1]] = prob
+                temp_pred[kf[n][1]] = _le.inverse_transform(prediction)
+                coefficients[clf_name].append(coefs)
+
+            confusions[clf_name] = temp
+            predictions[clf_name] = temp_pred
+            test_prob[clf_name] = temp_prob
+
+        # Voting
+        fitted_clfs = pd.DataFrame(fitted_clfs)
+        scores['Voting', 'train'] = np.zeros((n_folds, ))
+        scores['Voting', 'test'] = np.zeros((n_folds, ))
         temp = np.zeros((n_class, n_class))
         temp_pred = np.zeros((data.shape[0], ))
-        temp_prob = np.zeros((data.shape[0], ))
-        clfs = fitted_clfs[clf_name]
-        for n in range(n_folds):
-            train_score, test_score, prediction, prob, confusion,\
-                coefs, fitted_clf = result.pop(0)
-            clfs.append(fitted_clf)
-            scores.loc[n, (clf_name, 'train')] = train_score
-            scores.loc[n, (clf_name, 'test')] = test_score
-            temp += confusion
-            temp_prob[kf[n][1]] = prob
-            temp_pred[kf[n][1]] = _le.inverse_transform(prediction)
-            coefficients[clf_name].append(coefs)
+        for n, (train, test) in enumerate(kf):
+            clf = MyVoter(fitted_clfs.loc[n].values)
+            X, y = data[train, :], label[train]
+            scores.loc[n, ('Voting', 'train')] = _scorer(clf, X, y)
+            X, y = data[test, :], label[test]
+            scores.loc[n, ('Voting', 'test')] = _scorer(clf, X, y)
+            temp_pred[test] = clf.predict(X)
+            temp += confusion_matrix(y, temp_pred[test])
 
-        confusions[clf_name] = temp
-        predictions[clf_name] = temp_pred
-        test_prob[clf_name] = temp_prob
+        confusions['Voting'] = temp
+        predictions['Voting'] = temp_pred
+        test_prob['Voting'] = temp_pred
+        ######
 
-    # Voting
-    fitted_clfs = pd.DataFrame(fitted_clfs)
-    scores['Voting', 'train'] = np.zeros((n_folds, ))
-    scores['Voting', 'test'] = np.zeros((n_folds, ))
-    temp = np.zeros((n_class, n_class))
-    temp_pred = np.zeros((data.shape[0], ))
-    for n, (train, test) in enumerate(kf):
-        clf = MyVoter(fitted_clfs.loc[n].values)
-        X, y = data[train, :], label[train]
-        scores.loc[n, ('Voting', 'train')] = _scorer(clf, X, y)
-        X, y = data[test, :], label[test]
-        scores.loc[n, ('Voting', 'test')] = _scorer(clf, X, y)
-        temp_pred[test] = clf.predict(X)
-        temp += confusion_matrix(y, temp_pred[test])
+        # saving confusion matrices
+        if save:
+            with open('poly_' + project_name + '/confusions.pkl', 'wb') as f:
+                p.dump(confusions, f, protocol=2)
 
-    confusions['Voting'] = temp
-    predictions['Voting'] = temp_pred
-    test_prob['Voting'] = temp_pred
-    ######
-
-    # saving confusion matrices
-    if save:
-        with open('poly_' + project_name + '/confusions.pkl', 'wb') as f:
-            p.dump(confusions, f, protocol=2)
-
-    if verbose:
-        print(scores.astype('float').describe().transpose()
-              [['mean', 'std', 'min', 'max']])
-    return Report(scores=scores, confusions=confusions,
-                  predictions=predictions, test_prob=test_prob,
-                  coefficients=coefficients,
-                  feature_selection=feature_selection)
+        if verbose:
+            print(scores.astype('float').describe().transpose()
+                  [['mean', 'std', 'min', 'max']])
+        return Report(scores=scores, confusions=confusions,
+                      predictions=predictions, test_prob=test_prob,
+                      coefficients=coefficients,
+                      feature_selection=feature_selection)
 
 
 def _scorer(clf, X, y):

--- a/polyssifier/polyssifier.py
+++ b/polyssifier/polyssifier.py
@@ -84,84 +84,85 @@ def poly(data, label, n_folds=10, scale=True, exclude=[],
     kf = list(skf.split(np.zeros(data.shape[0]), label))
 
     # Parallel processing of tasks
-    manager = Manager()
-    args = manager.list()
-    args.append({})  # Store inputs
-    shared = args[0]
-    shared['kf'] = kf
-    shared['X'] = data
-    shared['y'] = label
-    args[0] = shared
+    if __name__ == '__main__':
+        manager = Manager()
+        args = manager.list()
+        args.append({})  # Store inputs
+        shared = args[0]
+        shared['kf'] = kf
+        shared['X'] = data
+        shared['y'] = label
+        args[0] = shared
 
-    args2 = []
-    for clf_name, val in classifiers.items():
-        for n_fold in range(n_folds):
-            args2.append((args, clf_name, val, n_fold, project_name,
-                          save, scoring))
+        args2 = []
+        for clf_name, val in classifiers.items():
+            for n_fold in range(n_folds):
+                args2.append((args, clf_name, val, n_fold, project_name,
+                              save, scoring))
 
-    if concurrency == 1:
-        result = list(starmap(fit_clf, args2))
-    else:
-        pool = Pool(processes=concurrency)
-        result = pool.starmap(fit_clf, args2)
-        pool.close()
+        if concurrency == 1:
+            result = list(starmap(fit_clf, args2))
+        else:
+            pool = Pool(processes=concurrency)
+            result = pool.starmap(fit_clf, args2)
+            pool.close()
 
-    fitted_clfs = {key: [] for key in classifiers}
+        fitted_clfs = {key: [] for key in classifiers}
 
-    # Gather results
-    for clf_name in classifiers:
-        coefficients[clf_name] = []
+        # Gather results
+        for clf_name in classifiers:
+            coefficients[clf_name] = []
+            temp = np.zeros((n_class, n_class))
+            temp_pred = np.zeros((data.shape[0], ))
+            temp_prob = np.zeros((data.shape[0], ))
+            clfs = fitted_clfs[clf_name]
+            for n in range(n_folds):
+                train_score, test_score, prediction, prob, confusion,\
+                    coefs, fitted_clf = result.pop(0)
+                clfs.append(fitted_clf)
+                scores.loc[n, (clf_name, 'train')] = train_score
+                scores.loc[n, (clf_name, 'test')] = test_score
+                temp += confusion
+                temp_prob[kf[n][1]] = prob
+                temp_pred[kf[n][1]] = _le.inverse_transform(prediction)
+                coefficients[clf_name].append(coefs)
+
+            confusions[clf_name] = temp
+            predictions[clf_name] = temp_pred
+            test_prob[clf_name] = temp_prob
+
+        # Voting
+        fitted_clfs = pd.DataFrame(fitted_clfs)
+        scores['Voting', 'train'] = np.zeros((n_folds, ))
+        scores['Voting', 'test'] = np.zeros((n_folds, ))
         temp = np.zeros((n_class, n_class))
         temp_pred = np.zeros((data.shape[0], ))
-        temp_prob = np.zeros((data.shape[0], ))
-        clfs = fitted_clfs[clf_name]
-        for n in range(n_folds):
-            train_score, test_score, prediction, prob, confusion,\
-                coefs, fitted_clf = result.pop(0)
-            clfs.append(fitted_clf)
-            scores.loc[n, (clf_name, 'train')] = train_score
-            scores.loc[n, (clf_name, 'test')] = test_score
-            temp += confusion
-            temp_prob[kf[n][1]] = prob
-            temp_pred[kf[n][1]] = _le.inverse_transform(prediction)
-            coefficients[clf_name].append(coefs)
+        for n, (train, test) in enumerate(kf):
+            clf = MyVoter(fitted_clfs.loc[n].values)
+            X, y = data[train, :], label[train]
+            scores.loc[n, ('Voting', 'train')] = _scorer(clf, X, y)
+            X, y = data[test, :], label[test]
+            scores.loc[n, ('Voting', 'test')] = _scorer(clf, X, y)
+            temp_pred[test] = clf.predict(X)
+            temp += confusion_matrix(y, temp_pred[test])
 
-        confusions[clf_name] = temp
-        predictions[clf_name] = temp_pred
-        test_prob[clf_name] = temp_prob
+        confusions['Voting'] = temp
+        predictions['Voting'] = temp_pred
+        test_prob['Voting'] = temp_pred
+        ######
 
-    # Voting
-    fitted_clfs = pd.DataFrame(fitted_clfs)
-    scores['Voting', 'train'] = np.zeros((n_folds, ))
-    scores['Voting', 'test'] = np.zeros((n_folds, ))
-    temp = np.zeros((n_class, n_class))
-    temp_pred = np.zeros((data.shape[0], ))
-    for n, (train, test) in enumerate(kf):
-        clf = MyVoter(fitted_clfs.loc[n].values)
-        X, y = data[train, :], label[train]
-        scores.loc[n, ('Voting', 'train')] = _scorer(clf, X, y)
-        X, y = data[test, :], label[test]
-        scores.loc[n, ('Voting', 'test')] = _scorer(clf, X, y)
-        temp_pred[test] = clf.predict(X)
-        temp += confusion_matrix(y, temp_pred[test])
+        # saving confusion matrices
+        if save:
+            with open('poly_' + project_name + '/confusions.pkl', 'wb') as f:
+                p.dump(confusions, f, protocol=2)
 
-    confusions['Voting'] = temp
-    predictions['Voting'] = temp_pred
-    test_prob['Voting'] = temp_pred
-    ######
-
-    # saving confusion matrices
-    if save:
-        with open('poly_' + project_name + '/confusions.pkl', 'wb') as f:
-            p.dump(confusions, f, protocol=2)
-
-    if verbose:
-        print(scores.astype('float').describe().transpose()
-              [['mean', 'std', 'min', 'max']])
-    return Report(scores=scores, confusions=confusions,
-                  predictions=predictions, test_prob=test_prob,
-                  coefficients=coefficients,
-                  feature_selection=feature_selection)
+        if verbose:
+            print(scores.astype('float').describe().transpose()
+                  [['mean', 'std', 'min', 'max']])
+        return Report(scores=scores, confusions=confusions,
+                      predictions=predictions, test_prob=test_prob,
+                      coefficients=coefficients,
+                      feature_selection=feature_selection)
 
 
 def _scorer(clf, X, y):

--- a/polyssifier/polyssifier.py
+++ b/polyssifier/polyssifier.py
@@ -85,29 +85,28 @@ def poly(data, label, n_folds=10, scale=True, exclude=[],
 
     # Parallel processing of tasks
     
-    if __name__ == 'polyssifier':
 
-        manager = Manager()
-        args = manager.list()
-        args.append({})  # Store inputs
-        shared = args[0]
-        shared['kf'] = kf
-        shared['X'] = data
-        shared['y'] = label
-        args[0] = shared
+    manager = Manager()
+    args = manager.list()
+    args.append({})  # Store inputs
+    shared = args[0]
+    shared['kf'] = kf
+    shared['X'] = data
+    shared['y'] = label
+    args[0] = shared
 
-        args2 = []
-        for clf_name, val in classifiers.items():
-            for n_fold in range(n_folds):
-                args2.append((args, clf_name, val, n_fold, project_name,
-                              save, scoring))
+    args2 = []
+    for clf_name, val in classifiers.items():
+        for n_fold in range(n_folds):
+            args2.append((args, clf_name, val, n_fold, project_name,
+                          save, scoring))
 
-        if concurrency == 1:
-            result = list(starmap(fit_clf, args2))
-        else:
-            pool = Pool(processes=concurrency)
-            result = pool.starmap(fit_clf, args2)
-            pool.close()
+    if concurrency == 1:
+        result = list(starmap(fit_clf, args2))
+    else:
+        pool = Pool(processes=concurrency)
+        result = pool.starmap(fit_clf, args2)
+        pool.close()
 
     fitted_clfs = {key: [] for key in classifiers}
 

--- a/polyssifier/report.py
+++ b/polyssifier/report.py
@@ -143,7 +143,7 @@ def plot_scores(scores, scoring='auc', file_name='temp', min_val=None):
             break
         ax1.text(rect.get_x() - rect.get_width() / 2., ymin + (1 - ymin) * .01,
                  data.index[n], ha='center', va='bottom',
-                 rotation='90', color='black', fontsize=15)
+                 rotation=90, color='black', fontsize=15)
     plt.tight_layout()
     plt.savefig(file_name + '.pdf')
     plt.savefig(file_name + '.svg', transparent=False)

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,6 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['pandas', 'sklearn', 'numpy', 'matplotlib'],
+    install_requires=['pandas', 'scikit-learn', 'numpy', 'matplotlib'],
     
     zip_safe=False) # Override annoying default behavior of easy_install.

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,12 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
 
     # What does your project relate to?

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,6 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['pandas', 'numpy', 'matplotlib'],
+    install_requires=['pandas','scikit-learn', 'numpy', 'matplotlib'],
     
     zip_safe=False) # Override annoying default behavior of easy_install.

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,6 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['pandas', 'scikit-learn', 'numpy', 'matplotlib'],
+    install_requires=['pandas', 'numpy', 'matplotlib'],
     
     zip_safe=False) # Override annoying default behavior of easy_install.

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,6 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['pandas','scikit-learn', 'numpy', 'matplotlib'],
+    install_requires=['pandas','scikit-learn', 'numpy', 'matplotlib','joblib'],
     
     zip_safe=False) # Override annoying default behavior of easy_install.

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -36,7 +36,7 @@ def test_run():
     report = poly(data, label, n_folds=2, verbose=1,
                   feature_selection=False,
                   save=False, project_name='test2')
-    for key, score in report.scores.mean().iteritems():
+    for key, score in report.scores.mean().items():
         assert score < 5, '{} score is too low'.format(key)
 
 
@@ -45,7 +45,7 @@ def test_multiclass():
     report = poly(data, label, n_folds=2, verbose=1,
                   feature_selection=False,
                   save=False, project_name='test3')
-    for key, score in report.scores.mean().iteritems():
+    for key, score in report.scores.mean().items():
         assert score < 5, '{} score is too low'.format(key)
 
         

--- a/tests/test_multiclass.py
+++ b/tests/test_multiclass.py
@@ -26,7 +26,7 @@ def test_run():
     report = poly(data, label, n_folds=2, verbose=1,
                   feature_selection=False,
                   save=False, project_name='test2')
-    for key, score in report.scores.mean().iteritems():
+    for key, score in report.scores.mean().items():
         assert score < 5, '{} score is too low'.format(key)
 
 

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -25,7 +25,7 @@ def test_feature_selection_regression():
     assert (report_with_features.scores.mean()[:, 'train'] > 0.2).all(),\
         'train score below chance'
 
-    for key, ypred in report_with_features.predictions.iteritems():
+    for key, ypred in report_with_features.predictions.items():
         mse = np.linalg.norm(ypred - diabetes_target) / len(diabetes_target)
         assert mse < 5, '{} Prediction error is too high'.format(key)
 


### PR DESCRIPTION
**OVERVIEW:**
Updated polyssifier to enable it to install via pip and run in Python 3 while maintaining Python 2.7 compatibility. 

Note that due to differences in Windows and Linux multiprocessing an additional line of code must be added prior to calling polyssifier in Windows:

if __name__ == '__main__':
         report = polyssifier.poly(data,labels)

**TESTING:**
Passed tests on Linux Python 3.7-3.12
Passed tests on Windows Python 3.7-3.12
Passed tests on Windows Python 2.7
Passed most tests on Linux Python 2.7

**MODIFICATIONS:**
Setup.py – changed ‘sklearn’ in install_requires to ‘scikit-learn’
Setup.py – added ‘joblib’ to install_requires to maintain Python 2.7 compatibility
Setup.py – added Python versions 3.7-3.12
Polyssifier.py – line 58 changed because fstring doesn’t work in Python 2
Poly_utils.py – lines 128 and 135 changed because max_features=’auto’ only works in scikit-learn 0.x. Switched to ‘sqrt’, which has identical outcome to ‘auto’ in scikit-learn 0.x but also works in scikit-learn 1.x.
Test_classification.py – lines 39 and 48, changed iteritems() to items() because iteritems() was deprecated in pandas 2.0
Test_multiclass.py – line 29, changed iteritems() to items() because iteritems() was deprecated in pandas 2.0
Test_regression.py – line 28, changed iteritems() to items() because iteritems() was deprecated in pandas 2.0